### PR TITLE
Исправление цветов терминала и включение поддержки мыши

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,49 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <source>25</source>
+                    <target>25</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <repositories>
         <repository>
             <id>jetbrains-intellij-deps</id>
             <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/</url>
         </repository>
     </repositories>
-
 
 </project>

--- a/src/main/java/org/mego/Main.java
+++ b/src/main/java/org/mego/Main.java
@@ -27,5 +27,7 @@ public class Main {
         } else {
             FlatDarkLaf.setup();
         }
+
+        UIManager.put("defaultFont", configManager.getFont());
     }
 }

--- a/src/main/java/org/mego/Main.java
+++ b/src/main/java/org/mego/Main.java
@@ -28,6 +28,6 @@ public class Main {
             FlatDarkLaf.setup();
         }
 
-        UIManager.put("defaultFont", configManager.getFont());
+        UIManager.put("defaultFont", configManager.getUiFont());
     }
 }

--- a/src/main/java/org/mego/config/ConfigManager.java
+++ b/src/main/java/org/mego/config/ConfigManager.java
@@ -31,7 +31,6 @@ public class ConfigManager {
         public String fontName = "Monospaced";
         public int fontSize = 14;
         public String theme = "Dark";
-        public String accentColor = null;
         public int x = 100;
         public int y = 100;
         public int width = 1000;
@@ -114,14 +113,6 @@ public class ConfigManager {
 
     public void setTheme(String theme) {
         config.theme = theme;
-    }
-
-    public String getAccentColor() {
-        return config.accentColor;
-    }
-
-    public void setAccentColor(String color) {
-        config.accentColor = color;
     }
 
     public int getX() {

--- a/src/main/java/org/mego/config/ConfigManager.java
+++ b/src/main/java/org/mego/config/ConfigManager.java
@@ -28,8 +28,10 @@ public class ConfigManager {
 
     public static class AppConfig {
 
-        public String fontName = "Monospaced";
-        public int fontSize = 14;
+        public String terminalFontName = "Monospaced";
+        public int terminalFontSize = 14;
+        public String uiFontName = "SansSerif";
+        public int uiFontSize = 14;
         public String theme = "Dark";
         public int x = 100;
         public int y = 100;
@@ -90,20 +92,36 @@ public class ConfigManager {
         }
     }
 
-    public String getFontName() {
-        return config.fontName;
+    public String getTerminalFontName() {
+        return config.terminalFontName;
     }
 
-    public void setFontName(String name) {
-        config.fontName = name;
+    public void setTerminalFontName(String name) {
+        config.terminalFontName = name;
     }
 
-    public int getFontSize() {
-        return config.fontSize;
+    public int getTerminalFontSize() {
+        return config.terminalFontSize;
     }
 
-    public void setFontSize(int size) {
-        config.fontSize = size;
+    public void setTerminalFontSize(int size) {
+        config.terminalFontSize = size;
+    }
+
+    public String getUiFontName() {
+        return config.uiFontName;
+    }
+
+    public void setUiFontName(String name) {
+        config.uiFontName = name;
+    }
+
+    public int getUiFontSize() {
+        return config.uiFontSize;
+    }
+
+    public void setUiFontSize(int size) {
+        config.uiFontSize = size;
     }
 
     public String getTheme() {
@@ -155,8 +173,12 @@ public class ConfigManager {
         config.maximized = maximized;
     }
 
-    public Font getFont() {
-        return new Font(config.fontName, Font.PLAIN, config.fontSize);
+    public Font getTerminalFont() {
+        return new Font(config.terminalFontName, Font.PLAIN, config.terminalFontSize);
+    }
+
+    public Font getUiFont() {
+        return new Font(config.uiFontName, Font.PLAIN, config.uiFontSize);
     }
 
     public List<ServerInfo> getFavorites() {

--- a/src/main/java/org/mego/ui/MainFrame.java
+++ b/src/main/java/org/mego/ui/MainFrame.java
@@ -145,15 +145,9 @@ public class MainFrame extends JFrame {
         }
         JMenuBar menuBar = new JMenuBar();
 
-        JMenu connMenu = new JMenu("Подключения");
-        JMenuItem newConnItem = new JMenuItem("Новое подключение");
-        newConnItem.addActionListener(e -> showNewConnectionDialog());
-        connMenu.add(newConnItem);
-
         favoritesMenu = new JMenu("Избранное");
-        connMenu.add(favoritesMenu);
 
-        JMenu settingsMenu = new JMenu("Настройки программы");
+        JMenu settingsMenu = new JMenu("Настройки");
         JMenuItem settingsItem = new JMenuItem("Параметры");
         settingsItem.addActionListener(e -> {
             new SettingsDialog(this, configManager).setVisible(true);
@@ -180,7 +174,7 @@ public class MainFrame extends JFrame {
         });
         helpMenu.add(aboutItem);
 
-        menuBar.add(connMenu);
+        menuBar.add(favoritesMenu);
         menuBar.add(settingsMenu);
         menuBar.add(helpMenu);
         setJMenuBar(menuBar);

--- a/src/main/java/org/mego/ui/SettingsDialog.java
+++ b/src/main/java/org/mego/ui/SettingsDialog.java
@@ -12,8 +12,10 @@ import java.awt.*;
 @Slf4j
 public class SettingsDialog extends JDialog {
 
-    private final JComboBox<String> fontNameCombo;
-    private final JSpinner fontSizeSpinner;
+    private final JComboBox<String> uiFontNameCombo;
+    private final JSpinner uiFontSizeSpinner;
+    private final JComboBox<String> terminalFontNameCombo;
+    private final JSpinner terminalFontSizeSpinner;
     private final JComboBox<String> themeCombo;
 
     public SettingsDialog(JFrame parent, ConfigManager configManager) {
@@ -27,38 +29,57 @@ public class SettingsDialog extends JDialog {
 
         gbc.anchor = GridBagConstraints.WEST;
 
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        gbc.fill = GridBagConstraints.NONE;
-        contentPanel.add(new JLabel("Шрифт:"), gbc);
-
         String[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
-        fontNameCombo = new JComboBox<>(fonts);
-        fontNameCombo.setSelectedItem(configManager.getFontName());
+
+        int row = 0;
+        gbc.gridx = 0;
+        gbc.gridy = row;
+        gbc.fill = GridBagConstraints.NONE;
+        contentPanel.add(new JLabel("Шрифт программы:"), gbc);
+
+        uiFontNameCombo = new JComboBox<>(fonts);
+        uiFontNameCombo.setSelectedItem(configManager.getUiFontName());
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;
-        contentPanel.add(fontNameCombo, gbc);
+        contentPanel.add(uiFontNameCombo, gbc);
 
+        row++;
         gbc.gridx = 0;
-        gbc.gridy = 1;
+        gbc.gridy = row;
         gbc.fill = GridBagConstraints.NONE;
-        contentPanel.add(new JLabel("Размер шрифта:"), gbc);
+        contentPanel.add(new JLabel("Размер шрифта программы:"), gbc);
 
-        fontSizeSpinner = new JSpinner(new SpinnerNumberModel(configManager.getFontSize(), 8, 72, 1));
-        fontSizeSpinner.setPreferredSize(new Dimension(60, fontSizeSpinner.getPreferredSize().height));
-        // Disable direct editing as requested ("убрать TextAria")
-        JComponent editor = fontSizeSpinner.getEditor();
-        if (editor instanceof JSpinner.DefaultEditor) {
-            JTextField textField = ((JSpinner.DefaultEditor) editor).getTextField();
-            textField.setColumns(3);
-            textField.setEditable(false);
-        }
+        uiFontSizeSpinner = createFontSizeSpinner(configManager.getUiFontSize());
         gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.NONE; // Don't stretch the spinner
-        contentPanel.add(fontSizeSpinner, gbc);
+        gbc.fill = GridBagConstraints.NONE;
+        contentPanel.add(uiFontSizeSpinner, gbc);
 
+        row++;
         gbc.gridx = 0;
-        gbc.gridy = 2;
+        gbc.gridy = row;
+        gbc.fill = GridBagConstraints.NONE;
+        contentPanel.add(new JLabel("Шрифт терминала:"), gbc);
+
+        terminalFontNameCombo = new JComboBox<>(fonts);
+        terminalFontNameCombo.setSelectedItem(configManager.getTerminalFontName());
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        contentPanel.add(terminalFontNameCombo, gbc);
+
+        row++;
+        gbc.gridx = 0;
+        gbc.gridy = row;
+        gbc.fill = GridBagConstraints.NONE;
+        contentPanel.add(new JLabel("Размер шрифта терминала:"), gbc);
+
+        terminalFontSizeSpinner = createFontSizeSpinner(configManager.getTerminalFontSize());
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.NONE;
+        contentPanel.add(terminalFontSizeSpinner, gbc);
+
+        row++;
+        gbc.gridx = 0;
+        gbc.gridy = row;
         gbc.fill = GridBagConstraints.NONE;
         contentPanel.add(new JLabel("Тема:"), gbc);
 
@@ -72,8 +93,10 @@ public class SettingsDialog extends JDialog {
         JButton saveButton = new JButton("Сохранить");
         saveButton.putClientProperty("FlatLaf.style", "arc: 10; background: #0078d4; foreground: #ffffff;");
         saveButton.addActionListener(e -> {
-            configManager.setFontName((String) fontNameCombo.getSelectedItem());
-            configManager.setFontSize((Integer) fontSizeSpinner.getValue());
+            configManager.setUiFontName((String) uiFontNameCombo.getSelectedItem());
+            configManager.setUiFontSize((Integer) uiFontSizeSpinner.getValue());
+            configManager.setTerminalFontName((String) terminalFontNameCombo.getSelectedItem());
+            configManager.setTerminalFontSize((Integer) terminalFontSizeSpinner.getValue());
             String theme = (String) themeCombo.getSelectedItem();
             configManager.setTheme(theme);
             configManager.save();
@@ -88,8 +111,9 @@ public class SettingsDialog extends JDialog {
         cancelButton.addActionListener(e -> dispose());
         buttonPanel.add(cancelButton);
 
+        row++;
         gbc.gridx = 0;
-        gbc.gridy = 4;
+        gbc.gridy = row;
         gbc.gridwidth = 2;
         contentPanel.add(buttonPanel, gbc);
 
@@ -97,6 +121,18 @@ public class SettingsDialog extends JDialog {
         setResizable(false);
         pack();
         setLocationRelativeTo(parent);
+    }
+
+    private JSpinner createFontSizeSpinner(int initialValue) {
+        JSpinner spinner = new JSpinner(new SpinnerNumberModel(initialValue, 8, 72, 1));
+        spinner.setPreferredSize(new Dimension(60, spinner.getPreferredSize().height));
+        JComponent editor = spinner.getEditor();
+        if (editor instanceof JSpinner.DefaultEditor) {
+            JTextField textField = ((JSpinner.DefaultEditor) editor).getTextField();
+            textField.setColumns(3);
+            textField.setEditable(false);
+        }
+        return spinner;
     }
 
     private void updateTheme(ConfigManager configManager) {

--- a/src/main/java/org/mego/ui/SettingsDialog.java
+++ b/src/main/java/org/mego/ui/SettingsDialog.java
@@ -106,6 +106,13 @@ public class SettingsDialog extends JDialog {
         });
         buttonPanel.add(saveButton);
 
+        // Разделитель
+        buttonPanel.add(Box.createRigidArea(new Dimension(10, 0))); // отступ
+        JSeparator separator = new JSeparator(SwingConstants.VERTICAL);
+        separator.setMaximumSize(new Dimension(2, 25));
+        buttonPanel.add(separator);
+        buttonPanel.add(Box.createRigidArea(new Dimension(10, 0))); // отступ после разделителя
+
         JButton cancelButton = new JButton("Отмена");
         cancelButton.putClientProperty("FlatLaf.style", "arc: 10;");
         cancelButton.addActionListener(e -> dispose());
@@ -125,12 +132,13 @@ public class SettingsDialog extends JDialog {
 
     private JSpinner createFontSizeSpinner(int initialValue) {
         JSpinner spinner = new JSpinner(new SpinnerNumberModel(initialValue, 8, 72, 1));
-        spinner.setPreferredSize(new Dimension(60, spinner.getPreferredSize().height));
+        spinner.setPreferredSize(new Dimension(70, spinner.getPreferredSize().height)); // чуть шире
         JComponent editor = spinner.getEditor();
         if (editor instanceof JSpinner.DefaultEditor) {
             JTextField textField = ((JSpinner.DefaultEditor) editor).getTextField();
             textField.setColumns(3);
             textField.setEditable(false);
+            textField.setFont(textField.getFont().deriveFont(16f)); // увеличиваем шрифт
         }
         return spinner;
     }

--- a/src/main/java/org/mego/ui/SettingsDialog.java
+++ b/src/main/java/org/mego/ui/SettingsDialog.java
@@ -15,13 +15,9 @@ public class SettingsDialog extends JDialog {
     private final JComboBox<String> fontNameCombo;
     private final JSpinner fontSizeSpinner;
     private final JComboBox<String> themeCombo;
-    private final JComboBox<String> accentCombo;
-
-    private static final String[] ACCENT_NAMES = {"Default", "Blue", "Orange", "Green", "Red", "Violet", "Gruvbox"};
-    private static final String[] ACCENT_VALUES = {null, "#0078d4", "#ff8c00", "#107c10", "#d13438", "#881798", "#79740e"};
 
     public SettingsDialog(JFrame parent, ConfigManager configManager) {
-        super(parent, "Настройки программы", true);
+        super(parent, "Настройки", true);
 
         JPanel contentPanel = new JPanel(new GridBagLayout());
         contentPanel.setBorder(new EmptyBorder(20, 20, 20, 20));
@@ -72,24 +68,6 @@ public class SettingsDialog extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         contentPanel.add(themeCombo, gbc);
 
-        gbc.gridx = 0;
-        gbc.gridy = 3;
-        gbc.fill = GridBagConstraints.NONE;
-        contentPanel.add(new JLabel("Акцент:"), gbc);
-
-        accentCombo = new JComboBox<>(ACCENT_NAMES);
-        String currentAccent = configManager.getAccentColor();
-        accentCombo.setSelectedIndex(0);
-        for (int i = 0; i < ACCENT_VALUES.length; i++) {
-            if (ACCENT_VALUES[i] != null && ACCENT_VALUES[i].equalsIgnoreCase(currentAccent)) {
-                accentCombo.setSelectedIndex(i);
-                break;
-            }
-        }
-        gbc.gridx = 1;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        contentPanel.add(accentCombo, gbc);
-
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton saveButton = new JButton("Сохранить");
         saveButton.putClientProperty("FlatLaf.style", "arc: 10; background: #0078d4; foreground: #ffffff;");
@@ -98,7 +76,6 @@ public class SettingsDialog extends JDialog {
             configManager.setFontSize((Integer) fontSizeSpinner.getValue());
             String theme = (String) themeCombo.getSelectedItem();
             configManager.setTheme(theme);
-            configManager.setAccentColor(ACCENT_VALUES[accentCombo.getSelectedIndex()]);
             configManager.save();
 
             updateTheme(configManager);

--- a/src/main/java/org/mego/ui/SshTerminalTab.java
+++ b/src/main/java/org/mego/ui/SshTerminalTab.java
@@ -4,6 +4,7 @@ import com.jediterm.terminal.TerminalColor;
 import com.jediterm.terminal.ui.JediTermWidget;
 import com.jediterm.terminal.ui.settings.DefaultSettingsProvider;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.mego.config.ConfigManager;
 import org.mego.ssh.SshTtyConnector;
 
@@ -47,13 +48,13 @@ public class SshTerminalTab extends JPanel {
             }
 
             @Override
-            public TerminalColor getDefaultForeground() {
+            public @NotNull TerminalColor getDefaultForeground() {
                 Color c = getThemeForeground();
                 return new TerminalColor(c.getRed(), c.getGreen(), c.getBlue());
             }
 
             @Override
-            public TerminalColor getDefaultBackground() {
+            public @NotNull TerminalColor getDefaultBackground() {
                 Color c = getThemeBackground();
                 return new TerminalColor(c.getRed(), c.getGreen(), c.getBlue());
             }

--- a/src/main/java/org/mego/ui/SshTerminalTab.java
+++ b/src/main/java/org/mego/ui/SshTerminalTab.java
@@ -62,6 +62,16 @@ public class SshTerminalTab extends JPanel {
             public boolean enableMouseReporting() {
                 return true;
             }
+
+            @Override
+            public boolean ambiguousCharsAreDoubleWidth() {
+                return false;
+            }
+
+            @Override
+            public boolean useAntialiasing() {
+                return true;
+            }
         }) {
             @Override
             protected JScrollBar createScrollBar() {

--- a/src/main/java/org/mego/ui/SshTerminalTab.java
+++ b/src/main/java/org/mego/ui/SshTerminalTab.java
@@ -1,5 +1,6 @@
 package org.mego.ui;
 
+import com.jediterm.terminal.TerminalColor;
 import com.jediterm.terminal.ui.JediTermWidget;
 import com.jediterm.terminal.ui.settings.DefaultSettingsProvider;
 import lombok.Getter;
@@ -44,6 +45,23 @@ public class SshTerminalTab extends JPanel {
             public float getTerminalFontSize() {
                 return configManager.getFontSize();
             }
+
+            @Override
+            public TerminalColor getDefaultForeground() {
+                Color c = getThemeForeground();
+                return new TerminalColor(c.getRed(), c.getGreen(), c.getBlue());
+            }
+
+            @Override
+            public TerminalColor getDefaultBackground() {
+                Color c = getThemeBackground();
+                return new TerminalColor(c.getRed(), c.getGreen(), c.getBlue());
+            }
+
+            @Override
+            public boolean enableMouseReporting() {
+                return true;
+            }
         }) {
             @Override
             protected JScrollBar createScrollBar() {
@@ -54,12 +72,32 @@ public class SshTerminalTab extends JPanel {
         };
 
         terminalWidget.setTtyConnector(connector);
+        terminalWidget.setBackground(getThemeBackground());
+        terminalWidget.setForeground(getThemeForeground());
         add(terminalWidget, BorderLayout.CENTER);
         terminalWidget.start();
     }
 
+    private Color getThemeBackground() {
+        String theme = configManager.getTheme();
+        if ("Светлый".equals(theme) || "Light".equals(theme)) {
+            return Color.WHITE;
+        }
+        return new Color(43, 43, 43);
+    }
+
+    private Color getThemeForeground() {
+        String theme = configManager.getTheme();
+        if ("Светлый".equals(theme) || "Light".equals(theme)) {
+            return Color.BLACK;
+        }
+        return Color.WHITE;
+    }
+
     public void updateSettings() {
         terminalWidget.setFont(configManager.getFont());
+        terminalWidget.setBackground(getThemeBackground());
+        terminalWidget.setForeground(getThemeForeground());
         terminalWidget.revalidate();
         terminalWidget.repaint();
     }

--- a/src/main/java/org/mego/ui/SshTerminalTab.java
+++ b/src/main/java/org/mego/ui/SshTerminalTab.java
@@ -38,12 +38,12 @@ public class SshTerminalTab extends JPanel {
         terminalWidget = new JediTermWidget(new DefaultSettingsProvider() {
             @Override
             public Font getTerminalFont() {
-                return configManager.getFont();
+                return configManager.getTerminalFont();
             }
 
             @Override
             public float getTerminalFontSize() {
-                return configManager.getFontSize();
+                return configManager.getTerminalFontSize();
             }
 
             @Override
@@ -105,7 +105,7 @@ public class SshTerminalTab extends JPanel {
     }
 
     public void updateSettings() {
-        terminalWidget.setFont(configManager.getFont());
+        terminalWidget.setFont(configManager.getTerminalFont());
         terminalWidget.setBackground(getThemeBackground());
         terminalWidget.setForeground(getThemeForeground());
         terminalWidget.revalidate();


### PR DESCRIPTION
Исправлены две основные проблемы с терминалом:
1. Цвета терминала теперь корректно меняются при переключении темы. Если выбрана темная тема, терминал будет иметь темный фон и светлый текст.
2. Включена поддержка мыши в терминале, что позволяет использовать интерактивные функции в таких программах, как htop.

Технические изменения:
- В классе `SshTerminalTab` переопределены методы `getDefaultForeground()` и `getDefaultBackground()` в `SettingsProvider`.
- Метод `enableMouseReporting()` теперь возвращает `true`.
- При обновлении настроек цвета теперь принудительно применяются к виджету терминала.

---
*PR created automatically by Jules for task [8052774479859321353](https://jules.google.com/task/8052774479859321353) started by @megoRU*