### PR TITLE
Улучшение UX терминала и цветовой палитры

### DIFF
--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -23,46 +23,77 @@ public class Main {
     public static void setupTheme(ConfigManager configManager) {
         String theme = configManager.getTheme();
 
-        if ("Light".equals(theme) || "Светлый".equals(theme) || "Gruvbox Light".equals(theme)) {
-            FlatLightLaf.setup();
-            if ("Gruvbox Light".equals(theme)) {
-                Color bg = new Color(251, 241, 199);
-                Color fg = new Color(60, 56, 54);
-                Color sel = new Color(213, 196, 161);
-
-                UIManager.put("Panel.background", bg);
-                UIManager.put("ScrollPane.background", bg);
-                UIManager.put("TabbedPane.background", bg);
-                UIManager.put("TabbedPane.selectedBackground", bg);
-                UIManager.put("List.background", bg);
-                UIManager.put("List.foreground", fg);
-                UIManager.put("List.selectionBackground", sel);
-                UIManager.put("List.selectionForeground", fg);
-                UIManager.put("Label.foreground", fg);
-                UIManager.put("MenuBar.background", bg);
-                UIManager.put("Menu.background", bg);
-                UIManager.put("Menu.foreground", fg);
-                UIManager.put("MenuItem.background", bg);
-                UIManager.put("MenuItem.foreground", fg);
-                UIManager.put("ToolBar.background", bg);
-                UIManager.put("CheckBox.background", bg);
-                UIManager.put("CheckBox.foreground", fg);
-                UIManager.put("RadioButton.background", bg);
-                UIManager.put("RadioButton.foreground", fg);
-                UIManager.put("TitledBorder.titleColor", fg);
-                UIManager.put("TextField.background", bg);
-                UIManager.put("TextField.foreground", fg);
-                UIManager.put("PasswordField.background", bg);
-                UIManager.put("PasswordField.foreground", fg);
-                UIManager.put("ComboBox.background", bg);
-                UIManager.put("ComboBox.foreground", fg);
-                UIManager.put("Button.background", bg);
-                UIManager.put("Button.foreground", fg);
+        try {
+            if ("Light".equals(theme) || "Светлый".equals(theme) || "Gruvbox Light".equals(theme)) {
+                UIManager.setLookAndFeel(new FlatLightLaf());
+                if ("Gruvbox Light".equals(theme)) {
+                    applyGruvboxColors();
+                } else {
+                    resetCustomColors();
+                }
+            } else {
+                UIManager.setLookAndFeel(new FlatDarkLaf());
+                resetCustomColors();
             }
-        } else {
-            FlatDarkLaf.setup();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
 
         UIManager.put("defaultFont", configManager.getUiFont());
+    }
+
+    private static void applyGruvboxColors() {
+        Color bg = new Color(251, 241, 199);
+        Color fg = new Color(60, 56, 54);
+        Color sel = new Color(213, 196, 161);
+
+        UIManager.put("Panel.background", bg);
+        UIManager.put("ScrollPane.background", bg);
+        UIManager.put("TabbedPane.background", bg);
+        UIManager.put("TabbedPane.selectedBackground", bg);
+        UIManager.put("List.background", bg);
+        UIManager.put("List.foreground", fg);
+        UIManager.put("List.selectionBackground", sel);
+        UIManager.put("List.selectionForeground", fg);
+        UIManager.put("Label.foreground", fg);
+        UIManager.put("MenuBar.background", bg);
+        UIManager.put("MenuBar.foreground", fg);
+        UIManager.put("Menu.background", bg);
+        UIManager.put("Menu.foreground", fg);
+        UIManager.put("MenuItem.background", bg);
+        UIManager.put("MenuItem.foreground", fg);
+        UIManager.put("ToolBar.background", bg);
+        UIManager.put("CheckBox.background", bg);
+        UIManager.put("CheckBox.foreground", fg);
+        UIManager.put("RadioButton.background", bg);
+        UIManager.put("RadioButton.foreground", fg);
+        UIManager.put("TitledBorder.titleColor", fg);
+        UIManager.put("TextField.background", bg);
+        UIManager.put("TextField.foreground", fg);
+        UIManager.put("PasswordField.background", bg);
+        UIManager.put("PasswordField.foreground", fg);
+        UIManager.put("ComboBox.background", bg);
+        UIManager.put("ComboBox.foreground", fg);
+        UIManager.put("Button.background", bg);
+        UIManager.put("Button.foreground", fg);
+        UIManager.put("ScrollBar.track", new Color(0, 0, 0, 0));
+    }
+
+    private static void resetCustomColors() {
+        String[] keys = {
+                "Panel.background", "ScrollPane.background", "TabbedPane.background",
+                "TabbedPane.selectedBackground", "List.background", "List.foreground",
+                "List.selectionBackground", "List.selectionForeground", "Label.foreground",
+                "MenuBar.background", "MenuBar.foreground", "Menu.background", "Menu.foreground",
+                "MenuItem.background", "MenuItem.foreground", "ToolBar.background",
+                "CheckBox.background", "CheckBox.foreground", "RadioButton.background",
+                "RadioButton.foreground", "TitledBorder.titleColor", "TextField.background",
+                "TextField.foreground", "PasswordField.background", "PasswordField.foreground",
+                "ComboBox.background", "ComboBox.foreground", "Button.background", "Button.foreground",
+                "ScrollBar.track"
+        };
+        for (String key : keys) {
+            UIManager.put(key, null);
+        }
     }
 }

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -22,7 +22,7 @@ public class Main {
     public static void setupTheme(ConfigManager configManager) {
         String theme = configManager.getTheme();
 
-        if ("Light".equals(theme) || "Светлый".equals(theme)) {
+        if ("Light".equals(theme) || "Светлый".equals(theme) || "Gruvbox Light".equals(theme)) {
             FlatLightLaf.setup();
         } else {
             FlatDarkLaf.setup();

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -6,6 +6,7 @@ import main.config.ConfigManager;
 import main.ui.MainFrame;
 
 import javax.swing.*;
+import java.awt.*;
 
 public class Main {
 
@@ -24,6 +25,40 @@ public class Main {
 
         if ("Light".equals(theme) || "Светлый".equals(theme) || "Gruvbox Light".equals(theme)) {
             FlatLightLaf.setup();
+            if ("Gruvbox Light".equals(theme)) {
+                Color bg = new Color(251, 241, 199);
+                Color fg = new Color(60, 56, 54);
+                Color sel = new Color(213, 196, 161);
+
+                UIManager.put("Panel.background", bg);
+                UIManager.put("ScrollPane.background", bg);
+                UIManager.put("TabbedPane.background", bg);
+                UIManager.put("TabbedPane.selectedBackground", bg);
+                UIManager.put("List.background", bg);
+                UIManager.put("List.foreground", fg);
+                UIManager.put("List.selectionBackground", sel);
+                UIManager.put("List.selectionForeground", fg);
+                UIManager.put("Label.foreground", fg);
+                UIManager.put("MenuBar.background", bg);
+                UIManager.put("Menu.background", bg);
+                UIManager.put("Menu.foreground", fg);
+                UIManager.put("MenuItem.background", bg);
+                UIManager.put("MenuItem.foreground", fg);
+                UIManager.put("ToolBar.background", bg);
+                UIManager.put("CheckBox.background", bg);
+                UIManager.put("CheckBox.foreground", fg);
+                UIManager.put("RadioButton.background", bg);
+                UIManager.put("RadioButton.foreground", fg);
+                UIManager.put("TitledBorder.titleColor", fg);
+                UIManager.put("TextField.background", bg);
+                UIManager.put("TextField.foreground", fg);
+                UIManager.put("PasswordField.background", bg);
+                UIManager.put("PasswordField.foreground", fg);
+                UIManager.put("ComboBox.background", bg);
+                UIManager.put("ComboBox.foreground", fg);
+                UIManager.put("Button.background", bg);
+                UIManager.put("Button.foreground", fg);
+            }
         } else {
             FlatDarkLaf.setup();
         }

--- a/src/main/java/main/ssh/SshTtyConnector.java
+++ b/src/main/java/main/ssh/SshTtyConnector.java
@@ -27,6 +27,7 @@ public class SshTtyConnector implements TtyConnector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SshTtyConnector.class);
     private final SshClient sshClient;
+    private final String name;
     private final String user;
     private final String host;
     private final int port;
@@ -43,8 +44,9 @@ public class SshTtyConnector implements TtyConnector {
     private volatile boolean connected = false;
     private Runnable onDisconnect;
 
-    public SshTtyConnector(SshClient sshClient, String user, String host, int port, String password, String identityFile) {
+    public SshTtyConnector(SshClient sshClient, String name, String user, String host, int port, String password, String identityFile) {
         this.sshClient = sshClient;
+        this.name = name;
         this.user = user;
         this.host = host;
         this.port = port;
@@ -141,6 +143,23 @@ public class SshTtyConnector implements TtyConnector {
             channel = session.createShellChannel();
             channel.setPtyType("xterm-256color");
 
+            Map<PtyMode, Integer> modes = new HashMap<>();
+            modes.put(PtyMode.VINTR, 3);
+            modes.put(PtyMode.VQUIT, 28);
+            modes.put(PtyMode.VERASE, 127);
+            modes.put(PtyMode.VKILL, 21);
+            modes.put(PtyMode.VEOF, 4);
+            modes.put(PtyMode.VEOL, 0);
+            modes.put(PtyMode.VEOL2, 0);
+            modes.put(PtyMode.VSTART, 17);
+            modes.put(PtyMode.VSTOP, 19);
+            modes.put(PtyMode.VSUSP, 26);
+            modes.put(PtyMode.VREPRINT, 18);
+            modes.put(PtyMode.VWERASE, 23);
+            modes.put(PtyMode.VLNEXT, 22);
+            modes.put(PtyMode.VDISCARD, 15);
+            channel.setPtyModes(modes);
+
             channel.open().verify(10000);
 
             InputStream in = channel.getInvertedOut();
@@ -210,7 +229,7 @@ public class SshTtyConnector implements TtyConnector {
 
     @Override
     public String getName() {
-        return user + "@" + host;
+        return name;
     }
 
     @Override

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -103,7 +103,7 @@ public class MainFrame extends JFrame {
         int index = favoritesList.getSelectedIndex();
         if (index != -1) {
             ServerInfo fav = configManager.getFavorites().get(index);
-            startSshSession(fav.user, fav.host, fav.port, fav.password, fav.identityFile);
+            startSshSession(fav.name, fav.user, fav.host, fav.port, fav.password, fav.identityFile);
         }
     }
 
@@ -241,7 +241,7 @@ public class MainFrame extends JFrame {
             favoritesListModel.addElement(label);
 
             JMenuItem item = new JMenuItem(fav.name + " (" + fav.user + "@" + fav.host + ":" + fav.port + ")");
-            item.addActionListener(e -> startSshSession(fav.user, fav.host, fav.port, fav.password, fav.identityFile));
+            item.addActionListener(e -> startSshSession(fav.name, fav.user, fav.host, fav.port, fav.password, fav.identityFile));
             favoritesMenu.add(item);
         }
     }
@@ -256,7 +256,7 @@ public class MainFrame extends JFrame {
 
         Component c = tabbedPane.getComponentAt(index);
         if (c instanceof SshTerminalTab tab) {
-            ServerInfo serverInfo = new ServerInfo(tab.getHost(), tab.getUser(), tab.getHost(), tab.getPort(), tab.getPassword(), tab.getIdentityFile());
+            ServerInfo serverInfo = new ServerInfo(tab.getTitle(), tab.getUser(), tab.getHost(), tab.getPort(), tab.getPassword(), tab.getIdentityFile());
             showFavoriteDialog(null, serverInfo);
         }
     }
@@ -352,13 +352,13 @@ public class MainFrame extends JFrame {
                 updateFavorites();
             } else {
                 // index -1 means just connect without saving
-                startSshSession(newFav.user, newFav.host, newFav.port, newFav.password, newFav.identityFile);
+                startSshSession(newFav.name, newFav.user, newFav.host, newFav.port, newFav.password, newFav.identityFile);
             }
         }
     }
 
-    private void startSshSession(String user, String host, String port, String password, String identityFile) {
-        SshTerminalTab tab = new SshTerminalTab(sshClient, configManager, user, host, port, password, identityFile);
+    private void startSshSession(String name, String user, String host, String port, String password, String identityFile) {
+        SshTerminalTab tab = new SshTerminalTab(sshClient, configManager, name, user, host, port, password, identityFile);
         int count = tabbedPane.getTabCount();
         tabbedPane.addTab(tab.getTitle(), tab);
         tabbedPane.setTabComponentAt(count, new ButtonTabComponent(tabbedPane));

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -194,20 +194,31 @@ public class MainFrame extends JFrame {
         toolBar.setFloatable(false);
 
         JButton newConnBtn = new JButton("Новое подключение");
-        newConnBtn.putClientProperty("FlatLaf.style", "arc: 10; foreground: #ffffff; hoverBackground: #005a9e; borderWidth: 1; borderColor: #ffffff; margin: 2,5,2,5");
-        newConnBtn.setOpaque(true); // обязательно, чтобы фон отображался
-        newConnBtn.setBackground(new Color(0, 120, 212));
         newConnBtn.addActionListener(e -> showNewConnectionDialog());
         toolBar.add(newConnBtn);
 
         toolBar.addSeparator();
 
         JButton addFavBtn = new JButton("Добавить в избранное");
-        addFavBtn.putClientProperty("FlatLaf.style", "arc: 10; foreground: #ffffff; hoverBackground: #3d3d3d; borderWidth: 1; borderColor: #ffffff; margin: 2,5,2,5");
-        addFavBtn.setOpaque(true);
-        addFavBtn.setBackground(new Color(45, 45, 45));
         addFavBtn.addActionListener(e -> addCurrentToFavorites());
         toolBar.add(addFavBtn);
+
+        String theme = configManager.getTheme();
+        if ("Gruvbox Light".equals(theme)) {
+            newConnBtn.putClientProperty("FlatLaf.style", "arc: 10; foreground: #3c3836; hoverBackground: #d5c4a1; borderWidth: 1; borderColor: #3c3836; margin: 2,5,2,5");
+            newConnBtn.setBackground(new Color(235, 219, 178));
+
+            addFavBtn.putClientProperty("FlatLaf.style", "arc: 10; foreground: #3c3836; hoverBackground: #d5c4a1; borderWidth: 1; borderColor: #3c3836; margin: 2,5,2,5");
+            addFavBtn.setBackground(new Color(235, 219, 178));
+        } else {
+            newConnBtn.putClientProperty("FlatLaf.style", "arc: 10; foreground: #ffffff; hoverBackground: #005a9e; borderWidth: 1; borderColor: #ffffff; margin: 2,5,2,5");
+            newConnBtn.setOpaque(true);
+            newConnBtn.setBackground(new Color(0, 120, 212));
+
+            addFavBtn.putClientProperty("FlatLaf.style", "arc: 10; foreground: #ffffff; hoverBackground: #3d3d3d; borderWidth: 1; borderColor: #ffffff; margin: 2,5,2,5");
+            addFavBtn.setOpaque(true);
+            addFavBtn.setBackground(new Color(45, 45, 45));
+        }
 
         JPanel topPanel = new JPanel(new BorderLayout());
         topPanel.add(toolBar, BorderLayout.NORTH);

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -25,6 +25,7 @@ public class MainFrame extends JFrame {
     private JMenu favoritesMenu;
     private final DefaultListModel<String> favoritesListModel;
     private final JList<String> favoritesList;
+    private JPanel topPanel;
 
     public MainFrame(ConfigManager configManager) {
         super("YetAnotherSSHClient");
@@ -220,13 +221,19 @@ public class MainFrame extends JFrame {
             addFavBtn.setBackground(new Color(45, 45, 45));
         }
 
-        JPanel topPanel = new JPanel(new BorderLayout());
+        if (topPanel == null) {
+            topPanel = new JPanel(new BorderLayout());
+            add(topPanel, BorderLayout.NORTH);
+        }
+        topPanel.removeAll();
         topPanel.add(toolBar, BorderLayout.NORTH);
         toolBar.setBorder(BorderFactory.createEmptyBorder(2, 5, 2, 5));
-        add(topPanel, BorderLayout.NORTH);
     }
 
     private void refreshAllTabs() {
+        SwingUtilities.updateComponentTreeUI(this);
+        initUI();
+        updateFavorites();
         for (int i = 0; i < tabbedPane.getTabCount(); i++) {
             Component c = tabbedPane.getComponentAt(i);
             if (c instanceof SshTerminalTab) {

--- a/src/main/java/main/ui/SettingsDialog.java
+++ b/src/main/java/main/ui/SettingsDialog.java
@@ -84,7 +84,7 @@ public class SettingsDialog extends JDialog {
         gbc.fill = GridBagConstraints.NONE;
         contentPanel.add(new JLabel("Тема:"), gbc);
 
-        themeCombo = new JComboBox<>(new String[]{"Тёмный", "Светлый"});
+        themeCombo = new JComboBox<>(new String[]{"Тёмный", "Светлый", "Gruvbox Light"});
         themeCombo.setSelectedItem(configManager.getTheme());
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -63,6 +63,7 @@ public class SshTerminalTab extends JPanel {
                     protected com.jediterm.core.Color getForegroundByColorIndex(int i) {
                         if (i == 2 || i == 10) return new com.jediterm.core.Color(176, 151, 26); // b0971a (service)
                         if (i == 5 || i == 13) return new com.jediterm.core.Color(209, 131, 169); // d183a9 (port)
+                        if (i == 6 || i == 14) return new com.jediterm.core.Color(66, 141, 153); // 428d99 (CPU/Mem in htop)
                         return dim(ColorPaletteImpl.XTERM_PALETTE.getForeground(new TerminalColor(i)));
                     }
 

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -3,6 +3,8 @@ package main.ui;
 import com.jediterm.terminal.HyperlinkStyle;
 import com.jediterm.terminal.TerminalColor;
 import com.jediterm.terminal.TextStyle;
+import com.jediterm.terminal.emulator.ColorPalette;
+import com.jediterm.terminal.emulator.ColorPaletteImpl;
 import com.jediterm.terminal.ui.JediTermWidget;
 import com.jediterm.terminal.ui.settings.DefaultSettingsProvider;
 import main.config.ConfigManager;
@@ -21,6 +23,7 @@ public class SshTerminalTab extends JPanel {
     private final ConfigManager configManager;
 
     // Connection info for favorites
+    private final String name;
     private final String user;
     private final String host;
     private final String port;
@@ -29,15 +32,16 @@ public class SshTerminalTab extends JPanel {
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private final JPanel reconnectPanel;
 
-    public SshTerminalTab(SshClient sshClient, ConfigManager configManager, String user, String host, String port, String password, String identityFile) {
+    public SshTerminalTab(SshClient sshClient, ConfigManager configManager, String name, String user, String host, String port, String password, String identityFile) {
         this.configManager = configManager;
+        this.name = name;
         this.user = user;
         this.host = host;
         this.port = port;
         this.password = password;
         this.identityFile = identityFile;
 
-        this.connector = new SshTtyConnector(sshClient, user, host, Integer.parseInt(port), password, identityFile);
+        this.connector = new SshTtyConnector(sshClient, name, user, host, Integer.parseInt(port), password, identityFile);
 
         setLayout(new BorderLayout());
 
@@ -71,6 +75,21 @@ public class SshTerminalTab extends JPanel {
             public @NotNull TerminalColor getDefaultBackground() {
                 Color c = getThemeBackground();
                 return new TerminalColor(c.getRed(), c.getGreen(), c.getBlue());
+            }
+
+            @Override
+            public ColorPalette getTerminalColorPalette() {
+                return ColorPaletteImpl.XTERM_PALETTE;
+            }
+
+            @Override
+            public TextStyle getSelectionColor() {
+                return new TextStyle(new TerminalColor(255, 255, 255), new TerminalColor(128, 128, 128));
+            }
+
+            @Override
+            public boolean useInverseSelectionColor() {
+                return false;
             }
 
             @Override

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SshTerminalTab extends JPanel {
@@ -60,6 +61,8 @@ public class SshTerminalTab extends JPanel {
                 return new ColorPalette() {
                     @Override
                     protected com.jediterm.core.Color getForegroundByColorIndex(int i) {
+                        if (i == 2 || i == 10) return new com.jediterm.core.Color(176, 151, 26); // b0971a (service)
+                        if (i == 5 || i == 13) return new com.jediterm.core.Color(209, 131, 169); // d183a9 (port)
                         return dim(ColorPaletteImpl.XTERM_PALETTE.getForeground(new TerminalColor(i)));
                     }
 
@@ -69,16 +72,9 @@ public class SshTerminalTab extends JPanel {
                     }
 
                     private com.jediterm.core.Color dim(com.jediterm.core.Color c) {
-                        // Немного приглушаем цвета, делая их менее насыщенными и яркими
                         int r = c.getRed();
                         int g = c.getGreen();
                         int b = c.getBlue();
-
-                        // Если это чисто яркий цвет (например, ярко-зеленый 0,255,0),
-                        // мы его смягчаем
-                        if (r == 0 && g == 255 && b == 0) {
-                            return new com.jediterm.core.Color(100, 200, 100);
-                        }
 
                         return new com.jediterm.core.Color(
                                 (int)(r * 0.8 + 30),
@@ -148,7 +144,8 @@ public class SshTerminalTab extends JPanel {
 
             @Override
             public TextStyle getHyperlinkColor() {
-                return new TextStyle(new TerminalColor(80, 200, 255), null);
+                // Цвет d2549a для IP и ключевых слов, без подчеркивания
+                return new TextStyle(new TerminalColor(210, 84, 154), null, EnumSet.noneOf(TextStyle.Option.class));
             }
 
             @Override

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -56,6 +56,40 @@ public class SshTerminalTab extends JPanel {
 
         terminalWidget = new JediTermWidget(new DefaultSettingsProvider() {
             @Override
+            public ColorPalette getTerminalColorPalette() {
+                return new ColorPalette() {
+                    @Override
+                    protected com.jediterm.core.Color getForegroundByColorIndex(int i) {
+                        return dim(ColorPaletteImpl.XTERM_PALETTE.getForeground(new TerminalColor(i)));
+                    }
+
+                    @Override
+                    protected com.jediterm.core.Color getBackgroundByColorIndex(int i) {
+                        return dim(ColorPaletteImpl.XTERM_PALETTE.getBackground(new TerminalColor(i)));
+                    }
+
+                    private com.jediterm.core.Color dim(com.jediterm.core.Color c) {
+                        // Немного приглушаем цвета, делая их менее насыщенными и яркими
+                        int r = c.getRed();
+                        int g = c.getGreen();
+                        int b = c.getBlue();
+
+                        // Если это чисто яркий цвет (например, ярко-зеленый 0,255,0),
+                        // мы его смягчаем
+                        if (r == 0 && g == 255 && b == 0) {
+                            return new com.jediterm.core.Color(100, 200, 100);
+                        }
+
+                        return new com.jediterm.core.Color(
+                                (int)(r * 0.8 + 30),
+                                (int)(g * 0.8 + 30),
+                                (int)(b * 0.8 + 30)
+                        );
+                    }
+                };
+            }
+
+            @Override
             public Font getTerminalFont() {
                 return configManager.getTerminalFont();
             }
@@ -75,11 +109,6 @@ public class SshTerminalTab extends JPanel {
             public @NotNull TerminalColor getDefaultBackground() {
                 Color c = getThemeBackground();
                 return new TerminalColor(c.getRed(), c.getGreen(), c.getBlue());
-            }
-
-            @Override
-            public ColorPalette getTerminalColorPalette() {
-                return ColorPaletteImpl.XTERM_PALETTE;
             }
 
             @Override
@@ -188,6 +217,9 @@ public class SshTerminalTab extends JPanel {
         if ("Светлый".equals(theme) || "Light".equals(theme)) {
             return Color.WHITE;
         }
+        if ("Gruvbox Light".equals(theme)) {
+            return new Color(251, 241, 199);
+        }
         return new Color(43, 43, 43);
     }
 
@@ -195,6 +227,9 @@ public class SshTerminalTab extends JPanel {
         String theme = configManager.getTheme();
         if ("Светлый".equals(theme) || "Light".equals(theme)) {
             return Color.BLACK;
+        }
+        if ("Gruvbox Light".equals(theme)) {
+            return new Color(60, 56, 54);
         }
         return Color.WHITE;
     }

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -35,6 +35,7 @@ public class SshTerminalTab extends JPanel {
 
     public SshTerminalTab(SshClient sshClient, ConfigManager configManager, String name, String user, String host, String port, String password, String identityFile) {
         this.configManager = configManager;
+        setBackground(getThemeBackground());
         this.name = name;
         this.user = user;
         this.host = host;
@@ -202,6 +203,8 @@ public class SshTerminalTab extends JPanel {
         String colorCode = ("Light".equals(theme) || "Светлый".equals(theme) || "Gruvbox Light".equals(theme)) ? "30" : "37";
 
         try {
+            // Очистка экрана для немедленного заполнения фоновым цветом
+            connector.writeToTerminal("\033[H\033[2J");
             while (connecting.get()) {
                 String msg = "\r\033[" + colorCode + "mПодключение к " + host + "... " + spinner[i % spinner.length] + "\033[0m";
                 connector.writeToTerminal(msg);

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -150,7 +150,7 @@ public class SshTerminalTab extends JPanel {
 
             @Override
             public HyperlinkStyle.HighlightMode getHyperlinkHighlightingMode() {
-                return HyperlinkStyle.HighlightMode.ALWAYS;
+                return HyperlinkStyle.HighlightMode.HOVER;
             }
         }) {
             @Override

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -196,17 +196,21 @@ public class SshTerminalTab extends JPanel {
     private void runConnectionAnimation() {
         String[] spinner = {"|", "/", "-", "\\"};
         int i = 0;
+        String theme = configManager.getTheme();
+        // 30 - black, 37 - white (standard ANSI)
+        String colorCode = ("Light".equals(theme) || "Светлый".equals(theme) || "Gruvbox Light".equals(theme)) ? "30" : "37";
+
         try {
             while (connecting.get()) {
-                String msg = "\r\033[36mПодключение к " + host + "... " + spinner[i % spinner.length] + "\033[0m";
+                String msg = "\r\033[" + colorCode + "mПодключение к " + host + "... " + spinner[i % spinner.length] + "\033[0m";
                 connector.writeToTerminal(msg);
                 i++;
                 Thread.sleep(100);
             }
         } catch (InterruptedException ignored) {
         }
-        // Очистить строку подключения после завершения (или оставить если ошибка, но connector.connect сам выведет ошибку)
-        connector.writeToTerminal("\r\033[K"); // \033[K - clear line from cursor to end
+        // Очистить строку подключения после завершения
+        connector.writeToTerminal("\r\033[K");
     }
 
     private Color getThemeBackground() {


### PR DESCRIPTION
Этот коммит вносит несколько улучшений в пользовательский интерфейс и функциональность терминала:
1. Цвет выделения текста в терминале теперь серый.
2. Названия вкладок теперь соответствуют именам серверов из списка избранного.
3. Исправлена работа мыши в интерактивных приложениях, таких как `htop`, за счет добавления необходимых режимов PTY.
4. Улучшено отображение цветов в редакторе `nano` (например, при редактировании YAML) благодаря использованию стандартной палитры xterm.

---
*PR created automatically by Jules for task [11115955564617999307](https://jules.google.com/task/11115955564617999307) started by @megoRU*