### PR TITLE
Исправление GruvboxLight и улучшения UI/UX

### DIFF
--- a/src/main/java/main/config/ConfigManager.java
+++ b/src/main/java/main/config/ConfigManager.java
@@ -29,9 +29,9 @@ public class ConfigManager {
     public static class AppConfig {
 
         public String terminalFontName = "Monospaced";
-        public int terminalFontSize = 14;
+        public int terminalFontSize = 17;
         public String uiFontName = "SansSerif";
-        public int uiFontSize = 14;
+        public int uiFontSize = 12;
         public String theme = "Dark";
         public int x = 100;
         public int y = 100;

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -215,19 +215,24 @@ public class MainFrame extends JFrame {
         helpMenu.setMnemonic('С');
         JMenuItem aboutItem = new JMenuItem("О программе");
         aboutItem.addActionListener(e -> {
-            JLabel label = new JLabel("<html>YetAnotherSSHClient<br>Версия: 1.0.1<br>GitHub: <a href=\"https://github.com/megoRU/YetAnotherSSHClient\">YetAnotherSSHClient</a></html>");
-            label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            label.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
+            JEditorPane editPane = new JEditorPane("text/html",
+                "<html><body style='font-family: sans-serif; font-size: 11pt;'>" +
+                "YetAnotherSSHClient<br>" +
+                "Версия: 1.0.1<br>" +
+                "GitHub: <a href=\"https://github.com/megoRU/YetAnotherSSHClient\">YetAnotherSSHClient</a>" +
+                "</body></html>");
+            editPane.setEditable(false);
+            editPane.setOpaque(false);
+            editPane.addHyperlinkListener(hle -> {
+                if (hle.getEventType() == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED) {
                     try {
-                        Desktop.getDesktop().browse(new java.net.URI("https://megoru.ru"));
+                        Desktop.getDesktop().browse(hle.getURL().toURI());
                     } catch (Exception ex) {
                         LOGGER.error("Failed to open link", ex);
                     }
                 }
             });
-            JOptionPane.showMessageDialog(this, label, "О программе", JOptionPane.INFORMATION_MESSAGE);
+            JOptionPane.showMessageDialog(this, editPane, "О программе", JOptionPane.INFORMATION_MESSAGE);
         });
         helpMenu.add(aboutItem);
 
@@ -318,7 +323,7 @@ public class MainFrame extends JFrame {
         nameField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "Название");
 
         JTextField hostField = new JTextField(initialData != null ? initialData.host : "");
-        hostField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "например, 192.168.1.1");
+        hostField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "IP");
 
         JTextField userField = new JTextField(initialData != null ? initialData.user : "root");
         userField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "имя пользователя");

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -215,11 +215,14 @@ public class MainFrame extends JFrame {
         helpMenu.setMnemonic('С');
         JMenuItem aboutItem = new JMenuItem("О программе");
         aboutItem.addActionListener(e -> {
+            JDialog dialog = new JDialog(this, "О программе", true);
+            dialog.setLayout(new BorderLayout());
+
             JEditorPane editPane = new JEditorPane("text/html",
-                "<html><body style='font-family: sans-serif; font-size: 11pt;'>" +
-                "YetAnotherSSHClient<br>" +
+                "<html><body style='font-family: sans-serif; font-size: 11pt; padding: 10px;'>" +
+                "<center>YetAnotherSSHClient<br>" +
                 "Версия: 1.0.1<br>" +
-                "GitHub: <a href=\"https://github.com/megoRU/YetAnotherSSHClient\">YetAnotherSSHClient</a>" +
+                "GitHub: <a href=\"https://github.com/megoRU/YetAnotherSSHClient\">YetAnotherSSHClient</a></center>" +
                 "</body></html>");
             editPane.setEditable(false);
             editPane.setOpaque(false);
@@ -232,7 +235,19 @@ public class MainFrame extends JFrame {
                     }
                 }
             });
-            JOptionPane.showMessageDialog(this, editPane, "О программе", JOptionPane.INFORMATION_MESSAGE);
+
+            JPanel btnPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            JButton exitBtn = new JButton("Выход");
+            exitBtn.putClientProperty(FlatClientProperties.STYLE, "arc: 10");
+            exitBtn.addActionListener(al -> dialog.dispose());
+            btnPanel.add(exitBtn);
+
+            dialog.add(editPane, BorderLayout.CENTER);
+            dialog.add(btnPanel, BorderLayout.SOUTH);
+            dialog.pack();
+            dialog.setSize(new Dimension(350, 200));
+            dialog.setLocationRelativeTo(this);
+            dialog.setVisible(true);
         });
         helpMenu.add(aboutItem);
 
@@ -393,11 +408,17 @@ public class MainFrame extends JFrame {
             okButtonText = "Добавить";
         }
 
-        int result = JOptionPane.showOptionDialog(this, panel, title,
-                JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
-                null, new Object[]{okButtonText, "Отмена"}, okButtonText);
+        JDialog dialog = new JDialog(this, title, true);
+        dialog.setLayout(new BorderLayout());
+        dialog.add(panel, BorderLayout.CENTER);
 
-        if (result == JOptionPane.OK_OPTION) {
+        JPanel btnPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton okBtn = new JButton(okButtonText);
+        okBtn.putClientProperty(FlatClientProperties.STYLE, "arc: 10");
+        JButton cancelBtn = new JButton("Отмена");
+        cancelBtn.putClientProperty(FlatClientProperties.STYLE, "arc: 10");
+
+        okBtn.addActionListener(e -> {
             ServerInfo newFav = new ServerInfo(
                     nameField.getText().isEmpty() ? hostField.getText() : nameField.getText(),
                     userField.getText(),
@@ -414,10 +435,20 @@ public class MainFrame extends JFrame {
                 configManager.updateFavorite(favoriteIndex, newFav);
                 updateFavorites();
             } else {
-                // index -1 means just connect without saving
                 startSshSession(newFav.name, newFav.user, newFav.host, newFav.port, newFav.password, newFav.identityFile);
             }
-        }
+            dialog.dispose();
+        });
+
+        cancelBtn.addActionListener(e -> dialog.dispose());
+
+        btnPanel.add(okBtn);
+        btnPanel.add(cancelBtn);
+        dialog.add(btnPanel, BorderLayout.SOUTH);
+
+        dialog.pack();
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
     }
 
     private void startSshSession(String name, String user, String host, String port, String password, String identityFile) {

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -353,7 +353,7 @@ public class MainFrame extends JFrame {
         passField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "пароль");
 
         JTextField keyField = new JTextField(initialData != null ? initialData.identityFile : "");
-        keyField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "путь к приватному ключу");
+        keyField.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "Путь");
         JButton keyBtn = new JButton("...");
         keyBtn.addActionListener(e -> {
             JFileChooser fc = new JFileChooser();

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -219,8 +219,8 @@ public class MainFrame extends JFrame {
             dialog.setLayout(new BorderLayout());
 
             JEditorPane editPane = new JEditorPane("text/html",
-                "<html><body style='font-family: sans-serif; font-size: 11pt; padding: 10px;'>" +
-                "<center>YetAnotherSSHClient<br>" +
+                "<html><body style='font-family: sans-serif; font-size: 13pt;'>" +
+                "<center><br><b>YetAnotherSSHClient</b><br>" +
                 "Версия: 1.0.1<br>" +
                 "GitHub: <a href=\"https://github.com/megoRU/YetAnotherSSHClient\">YetAnotherSSHClient</a></center>" +
                 "</body></html>");
@@ -237,15 +237,17 @@ public class MainFrame extends JFrame {
             });
 
             JPanel btnPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            btnPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 10));
             JButton exitBtn = new JButton("Выход");
             exitBtn.putClientProperty(FlatClientProperties.STYLE, "arc: 10");
+            exitBtn.setPreferredSize(new Dimension(100, 30));
             exitBtn.addActionListener(al -> dialog.dispose());
             btnPanel.add(exitBtn);
 
             dialog.add(editPane, BorderLayout.CENTER);
             dialog.add(btnPanel, BorderLayout.SOUTH);
             dialog.pack();
-            dialog.setSize(new Dimension(350, 200));
+            dialog.setSize(new Dimension(400, 220));
             dialog.setLocationRelativeTo(this);
             dialog.setVisible(true);
         });
@@ -330,6 +332,7 @@ public class MainFrame extends JFrame {
 
     private void showFavoriteDialog(Integer favoriteIndex, ServerInfo initialData) {
         JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBorder(BorderFactory.createEmptyBorder(10, 15, 10, 15));
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.insets = new Insets(5, 5, 5, 5);
@@ -413,6 +416,7 @@ public class MainFrame extends JFrame {
         dialog.add(panel, BorderLayout.CENTER);
 
         JPanel btnPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        btnPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 10));
         JButton okBtn = new JButton(okButtonText);
         okBtn.putClientProperty(FlatClientProperties.STYLE, "arc: 10");
         JButton cancelBtn = new JButton("Отмена");

--- a/src/main/java/main/ui/SettingsDialog.java
+++ b/src/main/java/main/ui/SettingsDialog.java
@@ -28,7 +28,6 @@ public class SettingsDialog extends JDialog {
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.insets = new Insets(10, 10, 10, 10);
-        contentPanel.putClientProperty(FlatClientProperties.STYLE, "rowSpacing: 10");
 
         gbc.anchor = GridBagConstraints.WEST;
 
@@ -94,7 +93,7 @@ public class SettingsDialog extends JDialog {
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton saveButton = new JButton("Сохранить");
-        saveButton.putClientProperty(FlatClientProperties.BUTTON_TYPE, FlatClientProperties.BUTTON_TYPE_ROUND_RECT);
+
         saveButton.addActionListener(e -> {
             configManager.setUiFontName((String) uiFontNameCombo.getSelectedItem());
             configManager.setUiFontSize((Integer) uiFontSizeSpinner.getValue());
@@ -110,11 +109,12 @@ public class SettingsDialog extends JDialog {
         buttonPanel.add(saveButton);
 
         // Разделитель
-        buttonPanel.add(Box.createRigidArea(new Dimension(10, 0))); // отступ
+        buttonPanel.add(Box.createRigidArea(new Dimension(1, 0))); // маленький отступ слева
         JSeparator separator = new JSeparator(SwingConstants.VERTICAL);
-        separator.setMaximumSize(new Dimension(2, 25));
+        separator.setPreferredSize(new Dimension(1, 20)); // тонкий и невысокий
+        separator.setMaximumSize(new Dimension(1, 20));
         buttonPanel.add(separator);
-        buttonPanel.add(Box.createRigidArea(new Dimension(10, 0))); // отступ после разделителя
+        buttonPanel.add(Box.createRigidArea(new Dimension(1, 0))); // маленький отступ справа
 
         JButton cancelButton = new JButton("Отмена");
         cancelButton.putClientProperty("FlatLaf.style", "arc: 10;");

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -80,12 +80,23 @@ public class SshTerminalTab extends JPanel {
                         if (i == 5 || i == 13) return new com.jediterm.core.Color(209, 131, 169); // d183a9 (port)
                         if (i == 6 || i == 14)
                             return new com.jediterm.core.Color(66, 141, 153); // 428d99 (CPU/Mem in htop)
-                        return dim(ColorPaletteImpl.XTERM_PALETTE.getForeground(new TerminalColor(i)));
+
+                        com.jediterm.core.Color c = ColorPaletteImpl.XTERM_PALETTE.getForeground(new TerminalColor(i));
+                        return com.formdev.flatlaf.FlatLaf.isLafDark() ? dim(c) : c;
                     }
 
                     @Override
                     protected com.jediterm.core.Color getBackgroundByColorIndex(int i) {
-                        return dim(ColorPaletteImpl.XTERM_PALETTE.getBackground(new TerminalColor(i)));
+                        com.jediterm.core.Color c = ColorPaletteImpl.XTERM_PALETTE.getBackground(new TerminalColor(i));
+                        if (!com.formdev.flatlaf.FlatLaf.isLafDark()) {
+                            // Если это белый или светло-серый фон в светлой теме, заменяем на цвет темы
+                            if (i == 7 || i == 15) {
+                                Color bg = getThemeBackground();
+                                return new com.jediterm.core.Color(bg.getRed(), bg.getGreen(), bg.getBlue());
+                            }
+                            return c;
+                        }
+                        return dim(c);
                     }
 
                     private com.jediterm.core.Color dim(com.jediterm.core.Color c) {
@@ -197,45 +208,32 @@ public class SshTerminalTab extends JPanel {
         if (connecting.compareAndSet(false, true)) {
             reconnectPanel.setVisible(false);
             new Thread(() -> {
-                Thread animationThread = new Thread(this::showConnectingDialog);
-                animationThread.start();
                 try {
+                    boolean isFirst = firstConnect.get();
+                    if (!isFirst) {
+                        SwingUtilities.invokeLater(() -> {
+                            terminalWidget.stop();
+                            terminalWidget.start();
+                        });
+                        // Даем немного времени на перезапуск виджета
+                        try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+                    }
+
+                    // Очистка экрана и вывод сообщения о подключении в терминал
+                    connector.writeToTerminal("\033[H\033[2J");
+                    String colorCode = com.formdev.flatlaf.FlatLaf.isLafDark() ? "\033[37m" : "\033[30m";
+                    connector.writeToTerminal(colorCode + "Подключение к " + host + "...\033[0m\r\n");
+
                     connector.connect();
-                    boolean isFirst = firstConnect.getAndSet(false);
-                    if (connector.isConnected() && !isFirst) {
-                        SwingUtilities.invokeLater(terminalWidget::start);
+                    if (connector.isConnected()) {
+                        firstConnect.set(false);
                     }
                 } finally {
                     connecting.set(false);
-                    animationThread.interrupt();
-                    try {
-                        animationThread.join();
-                    } catch (InterruptedException ignored) {
-                    }
                     connector.closePreConnectionPipe();
                 }
             }).start();
         }
-    }
-
-    private void showConnectingDialog() {
-        JDialog dialog = new JDialog(SwingUtilities.getWindowAncestor(this), "Подключение", Dialog.ModalityType.APPLICATION_MODAL);
-        JLabel label = new JLabel("Подключение к " + host + "...", SwingConstants.CENTER);
-        JProgressBar progressBar = new JProgressBar();
-        progressBar.setIndeterminate(true);
-
-        dialog.setLayout(new BorderLayout(5, 5));
-        dialog.add(label, BorderLayout.CENTER);
-        dialog.add(progressBar, BorderLayout.SOUTH);
-        dialog.setSize(300, 80);
-        dialog.setLocationRelativeTo(this);
-
-        new Thread(() -> {
-            connect(); // твой метод подключения
-            SwingUtilities.invokeLater(dialog::dispose); // закрыть окно после подключения
-        }).start();
-
-        dialog.setVisible(true);
     }
 
     private Color getThemeBackground() {

--- a/src/main/resources/themes/GruvboxLight.properties
+++ b/src/main/resources/themes/GruvboxLight.properties
@@ -40,6 +40,14 @@ ComboBox.foreground = @foreground
 
 Button.background = @header
 Button.foreground = @foreground
+Button.arc = 10
+
+# Primary button (default)
+Button.default.background = #d79921
+Button.default.foreground = @background
+
+# OptionPane
+OptionPane.buttonBackground = @header
 
 ToolBar.background = @background
 


### PR DESCRIPTION
Этот коммит исправляет ряд проблем в теме GruvboxLight и улучшает UX приложения:
1. Исправлены "белые квадраты" вокруг букв в терминале при использовании GruvboxLight (цвета ANSI 7 и 15 теперь соответствуют фону темы).
2. Уведомление о подключении теперь отображается прямо в табе терминала вместо модального окна.
3. Исправлены белые кнопки в диалогах (теперь они имеют корректные цвета Gruvbox и скругление).
4. В окне "О программе" ссылка теперь кликабельна только на тексте, а не на всем окне.
5. Плейсхолдер в поле хоста заменен на лаконичное "IP".

---
*PR created automatically by Jules for task [17926333912360924688](https://jules.google.com/task/17926333912360924688) started by @megoRU*