### PR TITLE
Авто-переподключение и заглушка для пустого окна

### DIFF
--- a/src/main/java/main/config/ConfigManager.java
+++ b/src/main/java/main/config/ConfigManager.java
@@ -38,6 +38,7 @@ public class ConfigManager {
         public int width = 1000;
         public int height = 700;
         public boolean maximized = false;
+        public boolean autoReconnect = true;
         public List<ServerInfo> favorites = new ArrayList<>();
     }
 
@@ -171,6 +172,14 @@ public class ConfigManager {
 
     public void setMaximized(boolean maximized) {
         config.maximized = maximized;
+    }
+
+    public boolean isAutoReconnect() {
+        return config.autoReconnect;
+    }
+
+    public void setAutoReconnect(boolean autoReconnect) {
+        config.autoReconnect = autoReconnect;
     }
 
     public Font getTerminalFont() {

--- a/src/main/java/main/ssh/SshTtyConnector.java
+++ b/src/main/java/main/ssh/SshTtyConnector.java
@@ -101,12 +101,14 @@ public class SshTtyConnector implements TtyConnector {
                     channel.close(true);
                 } catch (Exception ignored) {
                 }
+                channel = null;
             }
             if (session != null) {
                 try {
                     session.close(true);
                 } catch (Exception ignored) {
                 }
+                session = null;
             }
             ConnectFuture connectFuture = sshClient.connect(user, host, port).verify(10000);
             session = connectFuture.getSession();
@@ -241,6 +243,9 @@ public class SshTtyConnector implements TtyConnector {
             if (session != null) session.close(true);
         } catch (Exception e) {
             LOGGER.error("Error shutting down channel", e);
+        } finally {
+            channel = null;
+            session = null;
         }
     }
 }

--- a/src/main/java/main/ssh/SshTtyConnector.java
+++ b/src/main/java/main/ssh/SshTtyConnector.java
@@ -55,7 +55,7 @@ public class SshTtyConnector implements TtyConnector {
         initPreConnectionPipe();
     }
 
-    private void initPreConnectionPipe() {
+    public void initPreConnectionPipe() {
         this.pos = new PipedOutputStream();
         try {
             PipedInputStream pis = new PipedInputStream(pos);

--- a/src/main/java/main/ssh/SshTtyConnector.java
+++ b/src/main/java/main/ssh/SshTtyConnector.java
@@ -56,6 +56,7 @@ public class SshTtyConnector implements TtyConnector {
     }
 
     public void initPreConnectionPipe() {
+        closePreConnectionPipe();
         this.pos = new PipedOutputStream();
         try {
             PipedInputStream pis = new PipedInputStream(pos);

--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -24,6 +24,8 @@ public class MainFrame extends JFrame {
     private final ConfigManager configManager;
     private final SshClient sshClient;
     private final JTabbedPane tabbedPane;
+    private final JPanel contentPanel;
+    private final CardLayout contentLayout;
     private JMenu connectionMenu;
     private final DefaultListModel<String> favoritesListModel;
     private final JList<String> favoritesList;
@@ -61,6 +63,12 @@ public class MainFrame extends JFrame {
         });
         tabbedPane.putClientProperty(FlatClientProperties.TABBED_PANE_SHOW_TAB_SEPARATORS, true);
         tabbedPane.putClientProperty(FlatClientProperties.TABBED_PANE_SCROLL_BUTTONS_PLACEMENT, FlatClientProperties.TABBED_PANE_PLACEMENT_BOTH);
+
+        contentLayout = new CardLayout();
+        contentPanel = new JPanel(contentLayout);
+        contentPanel.add(tabbedPane, "tabs");
+        contentPanel.add(createPlaceholderPanel(), "placeholder");
+        contentLayout.show(contentPanel, "placeholder");
 
         favoritesListModel = new DefaultListModel<>();
         favoritesList = new JList<>(favoritesListModel);
@@ -115,7 +123,7 @@ public class MainFrame extends JFrame {
         favoritesList.setOpaque(true);
         sidebar.add(scrollPane, BorderLayout.CENTER);
 
-        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, sidebar, tabbedPane);
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, sidebar, contentPanel);
         splitPane.setDividerLocation(220);
         splitPane.setContinuousLayout(true);
         splitPane.putClientProperty(FlatClientProperties.STYLE, "dividerSize: 5; border: 0,0,0,0");
@@ -190,6 +198,25 @@ public class MainFrame extends JFrame {
             ((SshTerminalTab) c).close();
         }
         tabbedPane.remove(index);
+        updateContentVisibility();
+    }
+
+    private void updateContentVisibility() {
+        if (tabbedPane.getTabCount() == 0) {
+            contentLayout.show(contentPanel, "placeholder");
+        } else {
+            contentLayout.show(contentPanel, "tabs");
+        }
+    }
+
+    private JPanel createPlaceholderPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        JLabel label = new JLabel("<html><center>Выберите сервер из списка избранного слева<br>или создайте новое подключение.</center></html>");
+        label.setHorizontalAlignment(SwingConstants.CENTER);
+        label.setEnabled(false);
+        label.setFont(label.getFont().deriveFont(16f));
+        panel.add(label);
+        return panel;
     }
 
     private void initUI() {
@@ -458,6 +485,7 @@ public class MainFrame extends JFrame {
     private void startSshSession(String name, String user, String host, String port, String password, String identityFile) {
         SshTerminalTab tab = new SshTerminalTab(sshClient, configManager, name, user, host, port, password, identityFile);
         tabbedPane.addTab(tab.getTitle(), tab);
+        updateContentVisibility();
         tabbedPane.setSelectedComponent(tab);
         tab.requestFocusInWindow();
         tab.connect();

--- a/src/main/java/main/ui/SettingsDialog.java
+++ b/src/main/java/main/ui/SettingsDialog.java
@@ -1,6 +1,5 @@
 package main.ui;
 
-import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.FlatLaf;
 import main.Main;
 import main.config.ConfigManager;
@@ -91,12 +90,6 @@ public class SettingsDialog extends JDialog {
         gbc.gridx = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         contentPanel.add(themeCombo, gbc);
-
-        row++;
-        gbc.gridx = 0;
-        gbc.gridy = row;
-        gbc.fill = GridBagConstraints.NONE;
-        contentPanel.add(new JLabel("Авто-переподключение:"), gbc);
 
         autoReconnectCheckbox = new JCheckBox();
         autoReconnectCheckbox.setSelected(configManager.isAutoReconnect());

--- a/src/main/java/main/ui/SettingsDialog.java
+++ b/src/main/java/main/ui/SettingsDialog.java
@@ -19,6 +19,7 @@ public class SettingsDialog extends JDialog {
     private final JComboBox<String> terminalFontNameCombo;
     private final JSpinner terminalFontSizeSpinner;
     private final JComboBox<String> themeCombo;
+    private final JCheckBox autoReconnectCheckbox;
 
     public SettingsDialog(JFrame parent, ConfigManager configManager) {
         super(parent, "Настройки", true);
@@ -91,6 +92,18 @@ public class SettingsDialog extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         contentPanel.add(themeCombo, gbc);
 
+        row++;
+        gbc.gridx = 0;
+        gbc.gridy = row;
+        gbc.fill = GridBagConstraints.NONE;
+        contentPanel.add(new JLabel("Авто-переподключение:"), gbc);
+
+        autoReconnectCheckbox = new JCheckBox();
+        autoReconnectCheckbox.setSelected(configManager.isAutoReconnect());
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        contentPanel.add(autoReconnectCheckbox, gbc);
+
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton saveButton = new JButton("Сохранить");
 
@@ -101,6 +114,7 @@ public class SettingsDialog extends JDialog {
             configManager.setTerminalFontSize((Integer) terminalFontSizeSpinner.getValue());
             String theme = (String) themeCombo.getSelectedItem();
             configManager.setTheme(theme);
+            configManager.setAutoReconnect(autoReconnectCheckbox.isSelected());
             configManager.save();
 
             updateTheme(configManager);

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -56,7 +56,7 @@ public class SshTerminalTab extends JPanel {
             if (!connecting.get()) {
                 reconnectPanel.setVisible(true);
                 if (configManager.isAutoReconnect()) {
-                    startAutoReconnectTimer();
+                    connect();
                 }
             }
         }));

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SshTerminalTab extends JPanel {
 
-    private final JediTermWidget terminalWidget;
+    private JediTermWidget terminalWidget;
     private final SshTtyConnector connector;
     private final ConfigManager configManager;
 
@@ -71,6 +71,10 @@ public class SshTerminalTab extends JPanel {
         reconnectPanel.setVisible(false);
         add(reconnectPanel, BorderLayout.NORTH);
 
+        initTerminalWidget();
+    }
+
+    private void initTerminalWidget() {
         terminalWidget = new JediTermWidget(new DefaultSettingsProvider() {
 
             @Override
@@ -179,7 +183,15 @@ public class SshTerminalTab extends JPanel {
             new Thread(() -> {
                 try {
                     try {
-                        SwingUtilities.invokeAndWait(() -> terminalWidget.stop());
+                        SwingUtilities.invokeAndWait(() -> {
+                            if (terminalWidget != null) {
+                                terminalWidget.stop();
+                                remove(terminalWidget);
+                            }
+                            initTerminalWidget();
+                            revalidate();
+                            repaint();
+                        });
                     } catch (Exception e) {
                         e.printStackTrace();
                     }

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -13,6 +13,7 @@ import org.apache.sshd.client.SshClient;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.Timer;
 import java.awt.*;
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,6 +32,7 @@ public class SshTerminalTab extends JPanel {
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private final AtomicBoolean firstConnect = new AtomicBoolean(true);
     private final JPanel reconnectPanel;
+    private Timer autoReconnectTimer;
 
     public SshTerminalTab(SshClient sshClient, ConfigManager configManager, String name, String user, String host, String port, String password, String identityFile) {
         this.configManager = configManager;
@@ -50,7 +52,14 @@ public class SshTerminalTab extends JPanel {
         reconnectPanel.setBackground(new Color(200, 50, 50));
         reconnectPanel.setBorder(new javax.swing.border.EmptyBorder(2, 2, 2, 2));
 
-        this.connector.setOnDisconnect(() -> SwingUtilities.invokeLater(() -> reconnectPanel.setVisible(true)));
+        this.connector.setOnDisconnect(() -> SwingUtilities.invokeLater(() -> {
+            if (!connecting.get()) {
+                reconnectPanel.setVisible(true);
+                if (configManager.isAutoReconnect()) {
+                    startAutoReconnectTimer();
+                }
+            }
+        }));
 
         JButton reconnectBtn = new JButton("Соединение разорвано. Переподключиться?");
         reconnectBtn.putClientProperty(FlatClientProperties.BUTTON_TYPE, FlatClientProperties.BUTTON_TYPE_ROUND_RECT);
@@ -167,29 +176,55 @@ public class SshTerminalTab extends JPanel {
     public void connect() {
         if (connecting.compareAndSet(false, true)) {
             reconnectPanel.setVisible(false);
+            stopAutoReconnectTimer();
             new Thread(() -> {
                 try {
                     boolean isFirst = firstConnect.get();
                     if (!isFirst) {
-                        SwingUtilities.invokeLater(() -> {
-                            terminalWidget.close();
-                            terminalWidget.start();
-                        });
                         try {
-                            Thread.sleep(100);
-                        } catch (InterruptedException ignored) {
+                            SwingUtilities.invokeAndWait(() -> terminalWidget.close());
+                        } catch (Exception e) {
+                            e.printStackTrace();
                         }
                     }
 
+                    connector.initPreConnectionPipe();
                     connector.writeToTerminal("\033[H\033[2J");
                     connector.writeToTerminal("Подключение к " + host + "...\r\n");
+
+                    SwingUtilities.invokeLater(() -> terminalWidget.start());
+
                     connector.connect();
-                    if (connector.isConnected()) firstConnect.set(false);
+
+                    if (connector.isConnected()) {
+                        firstConnect.set(false);
+                    } else {
+                        if (configManager.isAutoReconnect()) {
+                            startAutoReconnectTimer();
+                        }
+                    }
                 } finally {
                     connecting.set(false);
                     connector.closePreConnectionPipe();
                 }
             }).start();
+        }
+    }
+
+    private void startAutoReconnectTimer() {
+        if (autoReconnectTimer != null && autoReconnectTimer.isRunning()) return;
+        autoReconnectTimer = new Timer(5000, e -> {
+            if (!connector.isConnected() && !connecting.get()) {
+                connect();
+            }
+        });
+        autoReconnectTimer.setRepeats(false);
+        autoReconnectTimer.start();
+    }
+
+    private void stopAutoReconnectTimer() {
+        if (autoReconnectTimer != null) {
+            autoReconnectTimer.stop();
         }
     }
 
@@ -212,6 +247,7 @@ public class SshTerminalTab extends JPanel {
     }
 
     public void close() {
+        stopAutoReconnectTimer();
         terminalWidget.close();
         if (connector != null) connector.close();
     }

--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -170,7 +170,6 @@ public class SshTerminalTab extends JPanel {
         terminalWidget.setForeground(getThemeForeground());
         terminalWidget.addHyperlinkFilter(new KeywordHighlighter());
         add(terminalWidget, BorderLayout.CENTER);
-        terminalWidget.start();
     }
 
     public void connect() {
@@ -179,13 +178,10 @@ public class SshTerminalTab extends JPanel {
             stopAutoReconnectTimer();
             new Thread(() -> {
                 try {
-                    boolean isFirst = firstConnect.get();
-                    if (!isFirst) {
-                        try {
-                            SwingUtilities.invokeAndWait(() -> terminalWidget.close());
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
+                    try {
+                        SwingUtilities.invokeAndWait(() -> terminalWidget.stop());
+                    } catch (Exception e) {
+                        e.printStackTrace();
                     }
 
                     connector.initPreConnectionPipe();

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,10 @@
+# SLF4J SimpleLogger configuration
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showLogName=true
+org.slf4j.simpleLogger.showShortLogName=false
+
+# Silence verbose SSH library logs
+org.slf4j.simpleLogger.log.org.apache.sshd=error


### PR DESCRIPTION
В рамках этой задачи были внесены изменения для улучшения стабильности SSH-сессий и пользовательского интерфейса:

- **Автоматическое переподключение**: Теперь клиент автоматически пытается восстановить соединение через 5 секунд после непредвиденного разрыва. Эту опцию можно отключить в настройках.
- **Исправление ввода в терминале**: Исправлена критическая ошибка, из-за которой после ручного или автоматического переподключения в терминал нельзя было вводить команды. Это было связано с тем, что потоки ввода-вывода старой сессии закрывались некорректно по отношению к новой сессии.
- **Интерфейс «пустого состояния»**: Когда в программе не открыто ни одной вкладки с терминалом, вместо пустого серого поля теперь отображается центрированная подсказка: «Выберите сервер из списка избранного слева или создайте новое подключение».
- **Настройки**: Добавлена новая опция в диалог настроек для управления поведением авто-переподключения.
- **Локализация**: Все новые элементы интерфейса выполнены на русском языке в соответствии с предпочтениями пользователя.

---
*PR created automatically by Jules for task [13518488701803864764](https://jules.google.com/task/13518488701803864764) started by @megoRU*