### PR TITLE
Смещение списка серверов вправо на 15 пикселей

### DIFF
--- a/src/main/java/main/ui/MainFrame.java
+++ b/src/main/java/main/ui/MainFrame.java
@@ -83,6 +83,7 @@ public class MainFrame extends JFrame {
         favoritesListModel = new DefaultListModel<>();
         favoritesList = new JList<>(favoritesListModel);
         favoritesList.setFixedCellHeight(30);
+        favoritesList.putClientProperty(FlatClientProperties.STYLE, "cellMargins: 0,15,0,0");
         favoritesList.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {


### PR DESCRIPTION
Внесены изменения в `MainFrame.java` для добавления отступа элементам списка серверов (избранного).
Использовано свойство `cellMargins: 0,15,0,0` через систему стилей FlatLaf.
Это позволяет сместить текст вправо на 15 пикселей, сохраняя при этом полосу выделения на всю ширину сайдбара, как просил пользователь.
Верхняя часть (заголовок и поиск) не затронута.

---
*PR created automatically by Jules for task [7387284953205041995](https://jules.google.com/task/7387284953205041995) started by @megoRU*