### PR TITLE
Fix terminal scrollbar style to match FlatLaf theme

### DIFF
--- a/src/main/java/main/ui/SshTerminalTab.java
+++ b/src/main/java/main/ui/SshTerminalTab.java
@@ -175,7 +175,9 @@ public class SshTerminalTab extends JPanel {
             @Override
             protected JScrollBar createScrollBar() {
                 JScrollBar bar = super.createScrollBar();
+                bar.updateUI();
                 bar.setUnitIncrement(16);
+                bar.putClientProperty(FlatClientProperties.SCROLL_BAR_SHOW_BUTTONS, false);
                 return bar;
             }
         };


### PR DESCRIPTION
The terminal scrollbar in JediTerm was not correctly picking up the FlatLaf theme, resulting in an "old" Swing look. This change overrides the scrollbar creation in SshTerminalTab to explicitly update its UI and apply FlatLaf-specific styling (hiding scroll buttons).

---
*PR created automatically by Jules for task [3860013816667490967](https://jules.google.com/task/3860013816667490967) started by @megoRU*